### PR TITLE
feat(admin): add authentication to protect delivery-requests route

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -50,6 +50,20 @@ app.post("/api/login", (req, res) => {
   );
 });
 
+// ADMIN LOGIN endpoint
+app.post("/api/admin-login", (req, res) => {
+  const { email, password } = req.body;
+  db.get(
+    "SELECT * FROM users WHERE email = ? AND password = ? AND type = 'Admin'",
+    [email, password],
+    (err, row) => {
+      if (err) return res.status(500).json({ message: "DB error" });
+      if (!row) return res.json({ message: "Invalid admin credentials" });
+      res.json({ message: "Admin login successful", user: row });
+    }
+  );
+});
+
 app.post('/api/donate-food', (req, res) => {
   const {
     userId,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,8 @@ import DeliveryPage from "./pages/DeliveryPage";
 import DashboardLayout from "./components/DashboardLayout";
 import PaymentSuccess from "./pages/PaymentSuccess";
 import AdminDeliveryRequestsPage from "./pages/AdminDeliveryRequestsPage";
+import AdminLoginPage from "./pages/AdminLoginPage";
+import ProtectedAdminRoute from "./components/ProtectedAdminRoute";
 // Wrapper for LandingPage (to use navigation)
 function LandingPageWrapper() {
   const navigate = useNavigate();
@@ -62,6 +64,7 @@ function App() {
         {/* Auth pages */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
+        <Route path="/admin-login" element={<AdminLoginPage />} />
 
         {/* Dashboard & sub-pages with layout */}
         <Route
@@ -109,7 +112,11 @@ function App() {
         <Route path="/success" element={<PaymentSuccess />} />
         {/* <Route path="/cancel" element={<PaymentCancel />} /> */}
 
-        <Route path="/admin/delivery-requests" element={<AdminDeliveryRequestsPage />} />
+        <Route path="/admin/delivery-requests" element={
+          <ProtectedAdminRoute>
+            <AdminDeliveryRequestsPage />
+          </ProtectedAdminRoute>
+        } />
 
       </Routes>
     </main>

--- a/frontend/src/components/ProtectedAdminRoute.jsx
+++ b/frontend/src/components/ProtectedAdminRoute.jsx
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+function ProtectedAdminRoute({ children }) {
+  const navigate = useNavigate();
+  const adminUser = JSON.parse(localStorage.getItem("adminUser"));
+
+  useEffect(() => {
+    if (!adminUser) {
+      navigate("/admin-login");
+    }
+  }, [navigate, adminUser]);
+
+  if (!adminUser) {
+    return <div>Redirecting to admin login...</div>;
+  }
+
+  return children;
+}
+
+export default ProtectedAdminRoute;

--- a/frontend/src/pages/AdminDeliveryRequestsPage.jsx
+++ b/frontend/src/pages/AdminDeliveryRequestsPage.jsx
@@ -39,6 +39,11 @@ export default function AdminDeliveryRequestsPage() {
     { label: "Delivered", data: delivered, color: "#28a745" },
   ];
 
+  const handleLogout = () => {
+    localStorage.removeItem("adminUser");
+    window.location.href = "/admin-login"; // Or navigate
+  };
+
   const TableHeader = () => (
   <thead style={{ backgroundColor: "#f2f2f2" }}>
     <tr>
@@ -185,7 +190,12 @@ export default function AdminDeliveryRequestsPage() {
 
   return (
     <div style={{ maxWidth: 1100, margin: "2rem auto", background: "#fff", padding: "2rem", borderRadius: 10, fontFamily: "Arial, sans-serif" }}>
-      <h1 style={{ marginBottom: '1rem' }}>📋 Admin: Delivery Requests</h1>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+        <h1>📋 Admin: Delivery Requests</h1>
+        <button onClick={handleLogout} style={{ background: '#dc3545', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4, cursor:'pointer' }}>
+          Logout
+        </button>
+      </div>
 
       {/* Tab Navigation */}
       <div style={{ display: "flex", marginBottom: 20, borderBottom: "2px solid #ddd" }}>

--- a/frontend/src/pages/AdminLoginPage.jsx
+++ b/frontend/src/pages/AdminLoginPage.jsx
@@ -1,0 +1,142 @@
+import React, { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { FiMail, FiLock, FiEye, FiEyeOff, FiArrowRight } from "react-icons/fi";
+import "./AuthPages.css"; 
+
+export default function AdminLoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleAdminLogin = async (e) => {
+    e.preventDefault();
+    if (!email || !password) {
+      setError("Please fill in all fields");
+      return;
+    }
+    setError("");
+    setIsLoading(true);
+
+    try {
+      const res = await fetch("http://localhost:5000/api/admin-login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password })
+      });
+
+      const data = await res.json();
+      if (data.message === "Admin login successful") {
+        localStorage.setItem("adminUser", JSON.stringify(data.user)); 
+        localStorage.removeItem("user"); 
+        navigate("/admin/delivery-requests");
+      } else {
+        setError(data.message || "Admin login failed");
+      }
+    } catch (error) {
+      setError("Network error. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-container">
+      <div className="auth-background">
+        <div className="auth-pattern"></div>
+        <div className="auth-overlay"></div>
+      </div>
+
+      <div className="auth-content">
+        <div className="auth-card">
+          <div className="auth-header">
+            <div className="auth-logo">
+              <span>🔐</span> 
+              <h1>Feedaily Admin</h1>
+            </div>
+            <h2>Admin Login</h2>
+            <p>Access admin dashboard for delivery management</p>
+          </div>
+
+          <form onSubmit={handleAdminLogin} className="auth-form">
+            {error && <div className="auth-error">{error}</div>}
+
+            <div className="input-group">
+              <FiMail className="input-icon" />
+              <input
+                type="email"
+                placeholder="Admin Email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className="auth-input"
+              />
+            </div>
+
+            <div className="input-group">
+              <FiLock className="input-icon" />
+              <input
+                type={showPassword ? "text" : "password"}
+                placeholder="Password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                className="auth-input"
+              />
+              <button
+                type="button"
+                className="password-toggle"
+                onClick={() => setShowPassword(!showPassword)}
+              >
+                {showPassword ? <FiEyeOff /> : <FiEye />}
+              </button>
+            </div>
+
+            <button 
+              type="submit" 
+              className="auth-button"
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <div className="spinner"></div>
+              ) : (
+                <>
+                  Admin Sign In
+                  <FiArrowRight />
+                </>
+              )}
+            </button>
+
+            <div className="auth-footer">
+              <p>
+                Back to regular login?{" "}
+                <Link to="/login" className="auth-link">
+                  User Login
+                </Link>
+              </p>
+            </div>
+          </form>
+        </div>
+
+        <div className="auth-hero">
+          <div className="hero-content">
+            <h3>Admin Access</h3>
+            <p>Manage deliveries and monitor platform activity</p>
+            <div className="hero-stats">
+              <div className="stat">
+                <span className="stat-number">📋</span>
+                <span className="stat-label">Delivery Requests</span>
+              </div>
+              <div className="stat">
+                <span className="stat-number">🚚</span>
+                <span className="stat-label">Active Deliveries</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/AuthPages.css
+++ b/frontend/src/pages/AuthPages.css
@@ -261,6 +261,16 @@
   font-size: 0.9rem;
 }
 
+.admin-login-link {
+  margin-top: 15px;  
+  text-align: center; 
+}
+
+.admin-login-link .auth-link {
+  font-weight: 700; 
+}
+
+
 .forgot-link:hover {
   color: #667eea;
   text-decoration: underline;

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -25,7 +25,7 @@ export default function LoginPage() {
       const res = await fetch("http://localhost:5000/api/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, password })
+        body: JSON.stringify({ email, password }),
       });
 
       const data = await res.json();
@@ -50,14 +50,18 @@ export default function LoginPage() {
       </div>
 
       {/* Debug logging for layout inspection */}
-      {console.log('Auth container dimensions:', {
-        container: document.querySelector('.auth-container')?.getBoundingClientRect(),
-        content: document.querySelector('.auth-content')?.getBoundingClientRect(),
-        card: document.querySelector('.auth-card')?.getBoundingClientRect(),
-        hero: document.querySelector('.auth-hero')?.getBoundingClientRect(),
-        stats: document.querySelector('.hero-stats')?.getBoundingClientRect()
+      {console.log("Auth container dimensions:", {
+        container: document
+          .querySelector(".auth-container")
+          ?.getBoundingClientRect(),
+        content: document
+          .querySelector(".auth-content")
+          ?.getBoundingClientRect(),
+        card: document.querySelector(".auth-card")?.getBoundingClientRect(),
+        hero: document.querySelector(".auth-hero")?.getBoundingClientRect(),
+        stats: document.querySelector(".hero-stats")?.getBoundingClientRect(),
       })}
-      
+
       <div className="auth-content">
         <div className="auth-card">
           <div className="auth-header">
@@ -103,11 +107,7 @@ export default function LoginPage() {
               </button>
             </div>
 
-            <button 
-              type="submit" 
-              className="auth-button"
-              disabled={isLoading}
-            >
+            <button type="submit" className="auth-button" disabled={isLoading}>
               {isLoading ? (
                 <div className="spinner"></div>
               ) : (
@@ -125,7 +125,14 @@ export default function LoginPage() {
                   Sign up now
                 </Link>
               </p>
-              <a href="#" className="forgot-link">Forgot password?</a>
+              <a href="#" className="forgot-link">
+                Forgot password?
+              </a>
+              <div className="admin-login-link">
+                <Link to="/admin-login" className="auth-link">
+                  Login as Admin
+                </Link>
+              </div>
             </div>
           </form>
         </div>
@@ -133,7 +140,9 @@ export default function LoginPage() {
         <div className="auth-hero">
           <div className="hero-content">
             <h3>Every Plate Matters</h3>
-            <p>Join thousands of users fighting food waste one meal at a time</p>
+            <p>
+              Join thousands of users fighting food waste one meal at a time
+            </p>
             <div className="hero-stats">
               <div className="stat">
                 <span className="stat-number">10K+</span>


### PR DESCRIPTION
Backend:
- Added `/api/admin-login` endpoint to handle admin-specific authentication.

Frontend:
- Created `AdminLoginPage.jsx` for dedicated admin login form (linked from `/login`).
- Updated `App.js` to add `/admin-login` route and wrap `/admin/delivery-requests` in `ProtectedAdminRoute`.
- Added "Login as Admin" link in `LoginPage.jsx`.
- Added logout button in `AdminDeliveryRequestsPage.jsx`.

Security:
- Direct access to `/admin/delivery-requests` now redirects to `/admin-login` for non-admin users.

Testing:
- Manually insert admin into SQLite DB:
  `INSERT INTO users (name, type, email, password, contact, address)
   VALUES ('Admin User', 'Admin', 'admin@feedaily.com', 'admin123', '1234567890', 'Admin Address');`

closes #14 