### PR TITLE
fix: preserve user details in donation form

### DIFF
--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -155,8 +155,10 @@ export default function DashboardPage() {
         const data = await res.json();
         setMessage(data.message);
         if (res.ok) {
-          setDonorName("");
-          setContact("");
+          // Reset form fields but keep user info from localStorage
+          const storedUser = JSON.parse(localStorage.getItem("user"));
+          setDonorName(storedUser?.name || "");
+          setContact(storedUser?.contact || "");
           setFoodType("");
           setQuantity("");
           setFreshness("");


### PR DESCRIPTION
## PR description

**Problem:**
- After successful donation submission, user name and contact fields were being reset to blank
- Users had to refresh the page to see their details again

**Solution:**
- Modified form reset logic to preserve user details from localStorage
- User information now persists without requiring page refresh