### PR TITLE
feat: Implement map modal for donation and route views

### DIFF
--- a/frontend/src/components/MapModal.jsx
+++ b/frontend/src/components/MapModal.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+const MapModal = ({ isOpen, onClose, mapUrl }) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  const modalOverlayStyle = {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+  };
+
+  const modalContentStyle = {
+    backgroundColor: '#fff',
+    padding: '20px',
+    borderRadius: '8px',
+    position: 'relative',
+    width: '80%',
+    maxWidth: '900px',
+    height: '80vh',
+    display: 'flex',
+    flexDirection: 'column',
+  };
+
+  const closeButtonStyle = {
+    position: 'absolute',
+    top: '10px',
+    right: '15px',
+    background: 'none',
+    border: 'none',
+    fontSize: '2rem',
+    cursor: 'pointer',
+    color: '#333',
+  };
+
+  const iframeContainerStyle = {
+    flexGrow: 1, 
+    marginTop: '20px',
+  };
+
+  return (
+    <div style={modalOverlayStyle} onClick={onClose}>
+      <div style={modalContentStyle} onClick={(e) => e.stopPropagation()}>
+        <button style={closeButtonStyle} onClick={onClose}>
+          &times;
+        </button>
+        <div style={iframeContainerStyle}>
+          <iframe
+            src={mapUrl}
+            width="100%"
+            height="100%"
+            style={{ border: 0 }}
+            allowFullScreen=""
+            loading="lazy"
+            referrerPolicy="no-referrer-when-downgrade"
+          ></iframe>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MapModal;

--- a/frontend/src/pages/AdminDeliveryRequestsPage.jsx
+++ b/frontend/src/pages/AdminDeliveryRequestsPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { FiLogOut } from "react-icons/fi";
+import MapModal from "../components/MapModal";
 import "./AdminDeliveryRequestsPage.css";
 
 export default function AdminDeliveryRequestsPage() {
@@ -7,6 +8,8 @@ export default function AdminDeliveryRequestsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [activeTab, setActiveTab] = useState("Available");
+  const [isMapModalOpen, setIsMapModalOpen] = useState(false);
+  const [mapModalUrl, setMapModalUrl] = useState('');
   const [expireModalOpenFor, setExpireModalOpenFor] = useState(null);
   const [expirationReason, setExpirationReason] = useState("");
   const expirationReasons = ["Spoiled", "Not picked up", "Other"];
@@ -43,6 +46,16 @@ export default function AdminDeliveryRequestsPage() {
   const handleLogout = () => {
     localStorage.removeItem("adminUser");
     window.location.href = "/admin-login";
+  };
+
+  const handleOpenMap = (url) => {
+    setMapModalUrl(url);
+    setIsMapModalOpen(true);
+  };
+
+  const handleCloseMap = () => {
+    setIsMapModalOpen(false);
+    setMapModalUrl('');
   };
 
   const TableHeader = () => (
@@ -103,16 +116,10 @@ export default function AdminDeliveryRequestsPage() {
           <>
             <td>
               {req.locationLat && req.locationLng ? (
-                <a
-                  href={`https://www.google.com/maps/search/?api=1&query=${req.locationLat},${req.locationLng}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+                <button className="admin-action-btn" onClick={() => handleOpenMap(`https://www.google.com/maps?q=${req.locationLat},${req.locationLng}&output=embed`)}>
                   View
-                </a>
-              ) : (
-                "N/A"
-              )}
+                </button>
+              ) : ( "N/A" )}
             </td>
             <td>{req.contact || "N/A"}</td>
             <td>
@@ -132,20 +139,11 @@ export default function AdminDeliveryRequestsPage() {
             </td>
             <td>{req.deliveryMethod || "N/A"}</td>
             <td>
-              {req.locationLat &&
-              req.locationLng &&
-              req.requesterLat &&
-              req.requesterLng ? (
-                <a
-                  href={`https://www.google.com/maps/dir/?api=1&origin=${req.locationLat},${req.locationLng}&destination=${req.requesterLat},${req.requesterLng}&travelmode=driving`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  View Route on Map
-                </a>
-              ) : (
-                "N/A"
-              )}
+              {req.locationLat && req.locationLng && req.requesterLat && req.requesterLng ? (
+                <button className="admin-action-btn" onClick={() => handleOpenMap(`https://www.google.com/maps?saddr=${req.requesterLat},${req.requesterLng}&daddr=${req.locationLat},${req.locationLng}&output=embed`)}>
+                  View Route
+                </button>
+              ) : ( "N/A" )}
             </td>
           </>
         )}
@@ -300,6 +298,12 @@ export default function AdminDeliveryRequestsPage() {
           </div>
         </div>
       )}
+
+      <MapModal 
+        isOpen={isMapModalOpen} 
+        onClose={handleCloseMap} 
+        mapUrl={mapModalUrl} 
+      />
     </div>
   );
 }

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import Webcam from "react-webcam";
 import TMImagePredictor from '../components/TMImagePredictor';
 import Carousel from "react-multi-carousel";
+import MapModal from '../components/MapModal';
 import "react-multi-carousel/lib/styles.css";
 import { 
   FiCamera, 
@@ -27,6 +28,8 @@ const responsive = {
 };
 
 export default function DashboardPage() {
+  const [isMapModalOpen, setIsMapModalOpen] = useState(false);
+  const [mapModalUrl, setMapModalUrl] = useState('');
   const [donorName, setDonorName] = useState("");
   const [contact, setContact] = useState("");
   const [foodType, setFoodType] = useState("");
@@ -262,6 +265,36 @@ export default function DashboardPage() {
     } else {
       alert("Could not start payment. Try again.");
     }
+  };
+
+  const handleOpenMap = (donation) => {
+    if (!navigator.geolocation) {
+      alert("Geolocation is not supported by your browser.");
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const requesterLat = position.coords.latitude;
+        const requesterLng = position.coords.longitude;
+        
+        const donorLat = donation.locationLat;
+        const donorLng = donation.locationLng;
+
+        const url = `https://www.google.com/maps?saddr=${requesterLat},${requesterLng}&daddr=${donorLat},${donorLng}&output=embed`;
+        
+        setMapModalUrl(url);
+        setIsMapModalOpen(true);
+      },
+      () => {
+        alert("Could not get your location. Please enable location services to view the route.");
+      }
+    );
+  };
+
+  const handleCloseMap = () => {
+    setIsMapModalOpen(false);
+    setMapModalUrl(''); 
   };
 
   return (
@@ -575,8 +608,8 @@ export default function DashboardPage() {
                       {donation.locationName ? donation.locationName : donation.locationLat && donation.locationLng ? `${donation.locationLat.toFixed(4)}, ${donation.locationLng.toFixed(4)}` : "Location not provided"}
                     </div>
                     {donation.locationLat && donation.locationLng && (
-                      <button onClick={() => window.open(`https://www.google.com/maps/search/?api=1&query=${donation.locationLat},${donation.locationLng}`, "_blank")} className="btn btn-ghost btn-xs">
-                        <FiMapPin /> Map
+                      <button onClick={() => handleOpenMap(donation)} className="btn btn-ghost btn-xs">
+                        <FiMapPin /> View Route
                       </button>
                     )}
                   </div>
@@ -707,6 +740,13 @@ export default function DashboardPage() {
           </div>
         </div>
       )}
+
+      <MapModal 
+        isOpen={isMapModalOpen} 
+        onClose={handleCloseMap} 
+        mapUrl={mapModalUrl} 
+      />
+
     </div>
   );
 }


### PR DESCRIPTION
Closes #27

This PR enhances the user experience by replacing external map links with a reusable in-app pop-up modal. This prevents users from having to leave the site to view donation locations or delivery routes.

### Key Changes
- **Reusable Component:** Created a new `MapModal.jsx` component to display Google Maps in an iframe.
- **User Dashboard:** Integrated the modal on the "Available Donations" card. It now shows the **route** from the user's current location to the donor's location.
- **Admin Page:** Integrated the modal in the "Delivery Requests" table to handle two cases:
    - Showing a **single-point** map for the donor's location.
    - Showing the full **delivery route** between the donor and requester.

All functionality has been tested locally and is working as expected.

